### PR TITLE
Start pile: ensure valid fist card (no wilds)

### DIFF
--- a/deck.py
+++ b/deck.py
@@ -77,3 +77,13 @@ def can_play_card(top: Card, playing: Card) -> bool:
             
     return False
     
+def draw_valid_start_card(deck: Deck) -> Card:
+    """Draw a valid starting card (not Wild or DrawFourWild). """
+    while True:
+        if len(deck.cards) == 0:
+            raise RuntimeError("Deck is empty; cannot draw a starting card. ")
+            
+        card = deck.cards.pop()
+        
+        if not isinstance(card, (Wild, DrawFourWild)):
+            return card

--- a/deck_test.py
+++ b/deck_test.py
@@ -38,6 +38,14 @@ class TestValidCards(unittest.TestCase):
 		self.assertTrue(can_play_card(Number(Color.BLUE, 10), Number(Color.BLUE, 5)))
 		self.assertFalse(can_play_card(Number(Color.BLUE, 10), Number(Color.RED, 5)))
 	
-    
+	def test_draw_valid_start_card(self):
+    		deck = Deck()
+    		deck.add_default_cards()
+
+    		card = draw_valid_start_card(deck)
+
+    		self.assertFalse(isinstance(card, (Wild, DrawFourWild)))
+
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
Implements the “start pile with valid first card”.
-Makes sure the game never starts with a Wild or Wild Draw Four card.
-A helper function that keeps drawing until it finds a valid starting card, and a test to confirm the behavior.