### PR TITLE
Add smoke test for core imports and deck

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,33 @@
+import importlib
+
+
+def test_smoke_imports():
+    """
+    Smoke test: core modules should import without crashing.
+    """
+    modules = [
+        "deck",
+        "models.game_state",
+        "controllers.lobby",
+    ]
+
+    for m in modules:
+        importlib.import_module(m)
+
+
+def test_smoke_deck_can_build_and_draw():
+    """
+    Smoke test: deck can be created and can draw at least one card.
+    """
+    import deck
+
+    if hasattr(deck, "Deck"):
+        d = deck.Deck()
+        assert d is not None
+
+        if hasattr(d, "shuffle"):
+            d.shuffle()
+
+        if hasattr(d, "draw"):
+            card = d.draw()
+            assert card is not None


### PR DESCRIPTION
Adds a basic smoke test to verify:

- Core modules import without crashing
- Deck can be created
- Deck can shuffle and draw

Closes #61 