### PR TITLE
Add views to pyproject.toml packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ test = [
 ]
 
 [tool.setuptools]
-packages = ["controllers", "models", "UI", "utils", "repos", "services", "tests"]
+packages = ["controllers", "models", "UI", "utils", "repos", "services", "tests", "views"]
 py-modules = ["__init__"]


### PR DESCRIPTION
This was messing up pylint, making it unable to import anything from views.