### PR TITLE
Fix lint action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m install pylint
-        python -m install .[test]
+        python -m pip install pylint
+        python -m pip install .[test]
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')


### PR DESCRIPTION
This should tell GitHub how to install all our dependencies so pylint can find them, finally fixing all pylint errors. Resolves #118.