### PR TITLE
Fix #123: Random starting number card

### DIFF
--- a/models/game_state.py
+++ b/models/game_state.py
@@ -169,8 +169,7 @@ class GameState:
 
         hands = _deal_starting_hands(self.state["players"], draw_pile)
         discard_pile: list[Card] = []
-        # _ = self._draw_first_valid_start_card(draw_pile, discard_pile)
-        discard_pile.append(Number(Color.RED, 0))
+        _ = self._draw_first_valid_start_card(draw_pile, discard_pile)
 
         self.state["hands"] = hands
         self.state["deck"] = draw_pile


### PR DESCRIPTION
Replaced fixed Red 0 start card with random valid Number card from deck.

Uses existing _draw_first_valid_start_card method to ensure:
- Start card is always a Number
- Deck remains valid
- No rule-breaking action cards start the game

All unit tests pass locally (16 passed).
Closes #123 