### PR TITLE
Fix lobby creation bug for users without profile pictures

### DIFF
--- a/views/base_views.py
+++ b/views/base_views.py
@@ -104,6 +104,6 @@ class BaseViews:
             embed.set_image(url=self.get_random_gif())
 
         if author:
-            embed.set_author(name=author.name, icon_url=author.avatar.url)
+            embed.set_author(name=author.name, icon_url=author.display_avatar.url)
 
         return embed


### PR DESCRIPTION
Game creation was failing for users without a custom profile picture because the code tried to access an avatar that didn’t exist. Updated it to use a fallback avatar so users without profile pictures can create a lobby without errors.

Closes #108 