### PR TITLE
Fix line length for pylint

### DIFF
--- a/controllers/uno_cog.py
+++ b/controllers/uno_cog.py
@@ -192,7 +192,12 @@ class UnoCog(commands.Cog):
                         f" <@{player_id}> was AFK. They drew a card and was skipped."
                     )
 
-                    await self._renderer.update_by_message_id(self.bot, channel_id, lobby.main_message, lobby)
+                    await self._renderer.update_by_message_id(
+                        self.bot,
+                        channel_id,
+                        lobby.main_message,
+                        lobby,
+                    )
 
                     asyncio.create_task(
                         self.run_afk_timer(


### PR DESCRIPTION
Fixes a pylint error caused by a line exceeding the 100 character limit in controllers/uno_cog.py.