### PR TITLE
Add host-only end game button and reset logic

### DIFF
--- a/services/game_service.py
+++ b/services/game_service.py
@@ -42,3 +42,10 @@ class GameService:
         """
         lobby = self.lobby_service.get_lobby(channel_id)
         return lobby.game.call_uno(caller_id)
+
+    def end_game(self, channel_id: int) -> None:
+        """
+        Ends the current game for a channel.
+        """
+        lobby = self.lobby_service.get_lobby(channel_id)
+        lobby.game.reset()


### PR DESCRIPTION
Adds a host-only End Game button to the game UI.

- Button only works if the interaction user is the lobby host.
- Calls GameService.end_game(channel_id).
- GameService resets the game state using GameState.reset().
- Renderer updates after reset and confirms game ended.

This allows the host to manually end a game at any time.
Closes #97 