### PR TITLE
Fix spacing in lobby

### DIFF
--- a/views/lobby_views.py
+++ b/views/lobby_views.py
@@ -30,7 +30,7 @@ class LobbyViews(BaseViews):
             author=lobby.user,
         )
 
-        users_str = mention(lobby.user.id) + "(Host)"
+        users_str = mention(lobby.user.id) + " (Host)"
 
         for player in lobby.game.players():
             if player == lobby.user.id:


### PR DESCRIPTION
Previously, the mentioned user appeared right next to the "(Host)" designation in the lobby. This adds a space so it doesn't look as horizontally compressed.